### PR TITLE
Add ability to set default path and filename on Neutralino.os methods…

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -322,6 +322,7 @@ json getEnv(const json &input) {
 json showOpenDialog(const json &input) {
     json output;
     string title = "Open a file";
+    string defaultPath = "";
     vector <string> filters = {"All files", "*"};
     pfd::opt option = pfd::opt::none;
 
@@ -337,8 +338,12 @@ json showOpenDialog(const json &input) {
         filters.clear();
         filters = __extensionsToVector(input["filters"]);
     }
+    
+    if(helpers::hasField(input, "defaultPath")) {
+        defaultPath = input["defaultPath"].get<string>();
+    }
 
-    vector<string> selectedEntries = pfd::open_file(title, "", filters, option).result();
+    vector<string> selectedEntries = pfd::open_file(title, defaultPath, filters, option).result();
 
     for(string &entry: selectedEntries) {
         entry = helpers::normalizePath(entry);
@@ -352,12 +357,17 @@ json showOpenDialog(const json &input) {
 json showFolderDialog(const json &input) {
     json output;
     string title = "Select a folder";
+    string defaultPath = "";
 
     if(helpers::hasField(input, "title")) {
         title = input["title"].get<string>();
     }
+    
+    if(helpers::hasField(input, "defaultPath")) {
+        defaultPath = input["defaultPath"].get<string>();
+    }
 
-    string selectedEntry = pfd::select_folder(title, "", pfd::opt::none).result();
+    string selectedEntry = pfd::select_folder(title, defaultPath, pfd::opt::none).result();
 
     output["returnValue"] = helpers::normalizePath(selectedEntry);
     output["success"] = true;
@@ -367,6 +377,7 @@ json showFolderDialog(const json &input) {
 json showSaveDialog(const json &input) {
     json output;
     string title = "Save a file";
+    string defaultPath = "";
     vector <string> filters = {"All files", "*"};
     pfd::opt option = pfd::opt::none;
 
@@ -383,7 +394,11 @@ json showSaveDialog(const json &input) {
         filters = __extensionsToVector(input["filters"]);
     }
 
-    string selectedEntry = pfd::save_file(title, "", filters, option).result();
+    if(helpers::hasField(input, "defaultPath")) {
+        defaultPath = input["defaultPath"].get<string>();
+    }
+
+    string selectedEntry = pfd::save_file(title, defaultPath, filters, option).result();
 
     output["returnValue"] = helpers::normalizePath(selectedEntry);
     output["success"] = true;


### PR DESCRIPTION
… like showSaveDialog() (#923)

* Made small change to showSaveDialog to allow setting the default path & filename.

* Added option for open_file & select_folder.

portable-file-dialogs supports the feature for open_file & select_folder too, so here's an additional commit to enable the feature.

* Fixed the missing defaultPath variables.

I think next time I make a PR, I'll avoid the in-browser GitHub editor, hopefully this makes everything checkout correctly.

Koda

## Description
<!--
    Give a brief explanation about the changes you are proposing.
-->

## Changes proposed
<!--
    List the changes you made, one or two bullets is ok, 3 or more is maybe
    that you are doing more than neccessary.
-->

 - Change 1
 - Change 2
 - etc..

## How to test it
<!--
    Give steps to test your changes for quality assurance tests.
-->

 - Run specs/tests

## Next steps
<!--
    If your pull request is just a step in a set of steps, mention the next steps.
-->

None.

## Deploy notes
<!--
    Notes about how to deploy the feature/enhancement you are deploying.
-->

None.